### PR TITLE
Refined benchmark per #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,34 +30,38 @@ Wherever possible, the number of shards for a map is set to 32.
 Benchmarked with Go 1.19.3 on Ubuntu 22.04.1 LTS using AMD Ryzen 7 Microsoft Surface (R) Edition, 2000 Mhz, 8 Core(s), 16 Logical Processor(s)
 
 ```
-BenchmarkUnshardedSingleMutex/Get-16                     2124543               674.6 ns/op
-BenchmarkUnshardedSingleMutex/Set-16                      679298              1842 ns/op
-BenchmarkUnshardedSingleMutex/Mix-16                     1373188               871.1 ns/op
-BenchmarkUnshardedSingleRWMutex/Get-16                   3188382               328.2 ns/op
-BenchmarkUnshardedSingleRWMutex/Set-16                   1000000              2006 ns/op
-BenchmarkUnshardedSingleRWMutex/Mix-16                   1580175               780.6 ns/op
-BenchmarkShardedMultiMutexMap/Get-16                     2033330               742.8 ns/op
-BenchmarkShardedMultiMutexMap/Set-16                      567921              1974 ns/op
-BenchmarkShardedMultiMutexMap/Mix-16                     1884939               693.2 ns/op
-BenchmarkShardedMultiRWMutexMap/Get-16                   1635735               759.5 ns/op
-BenchmarkShardedMultiRWMutexMap/Set-16                    682179              1663 ns/op
-BenchmarkShardedMultiRWMutexMap/Mix-16                   1705411               782.6 ns/op
-BenchmarkShardedMultiSegragatedRWMutexMap/Get-16                 2054887               765.3 ns/op
-BenchmarkShardedMultiSegragatedRWMutexMap/Set-16                  988224              1571 ns/op
-BenchmarkShardedMultiSegragatedRWMutexMap/Mix-16                 1426081               814.1 ns/op
-BenchmarkOrcamanLibrary/Get-16                                   1778530               832.0 ns/op
-BenchmarkOrcamanLibrary/Set-16                                    585670              1929 ns/op
-BenchmarkOrcamanLibrary/Mix-16                                   1363203               950.8 ns/op
-BenchmarkFanLiaoLibrary/Get-16                                   1000000              1031 ns/op
-BenchmarkFanLiaoLibrary/Set-16                                    533665              1901 ns/op
-BenchmarkFanLiaoLibrary/Mix-16                                   1000000              1100 ns/op
-BenchmarkTidwallLibrary/Get-16                                   1604966               856.9 ns/op
-BenchmarkTidwallLibrary/Set-16                                    801894              1803 ns/op
-BenchmarkTidwallLibrary/Mix-16                                   1257034               904.7 ns/op
-BenchmarkDustinxieLibrary/Get-16                                 1325163               931.9 ns/op
-BenchmarkDustinxieLibrary/Set-16                                  698587              1753 ns/op
-BenchmarkDustinxieLibrary/Mix-16                                 1000000              1045 ns/op
-BenchmarkSyncMap/Get-16                                          1772929               726.8 ns/op
-BenchmarkSyncMap/Set-16                                           533874              2994 ns/op
-BenchmarkSyncMap/Mix-16                                          1536703               764.5 ns/op
+goos: linux
+goarch: amd64
+pkg: github.com/s0lesurviv0r/go-concurrent-map-bench
+cpu: AMD Ryzen 7 Microsoft Surface (R) Edition
+BenchmarkUnshardedSingleMutex/Get-16                    12281431               183.0 ns/op
+BenchmarkUnshardedSingleMutex/Set-16                     1000000              1254 ns/op
+BenchmarkUnshardedSingleMutex/Mix-16                     3029019               413.7 ns/op
+BenchmarkUnshardedSingleRWMutex/Get-16                  33020790                35.65 ns/op
+BenchmarkUnshardedSingleRWMutex/Set-16                   1000000              1162 ns/op
+BenchmarkUnshardedSingleRWMutex/Mix-16                  27542838                43.36 ns/op
+BenchmarkShardedMultiMutexMap/Get-16                    59081289                20.27 ns/op
+BenchmarkShardedMultiMutexMap/Set-16                    11379960                93.48 ns/op
+BenchmarkShardedMultiMutexMap/Mix-16                    23267588                47.41 ns/op
+BenchmarkShardedMultiRWMutexMap/Get-16                  59250309                20.14 ns/op
+BenchmarkShardedMultiRWMutexMap/Set-16                  11466465                94.43 ns/op
+BenchmarkShardedMultiRWMutexMap/Mix-16                  31438360                35.26 ns/op
+BenchmarkShardedMultiSegragatedRWMutexMap/Get-16                62492812                19.86 ns/op
+BenchmarkShardedMultiSegragatedRWMutexMap/Set-16                11220654                99.37 ns/op
+BenchmarkShardedMultiSegragatedRWMutexMap/Mix-16                33407506                31.77 ns/op
+BenchmarkOrcamanLibrary/Get-16                                  57665552                20.80 ns/op
+BenchmarkOrcamanLibrary/Set-16                                  11423337                94.70 ns/op
+BenchmarkOrcamanLibrary/Mix-16                                  28998466                35.13 ns/op
+BenchmarkFanLiaoLibrary/Get-16                                  52634571                22.25 ns/op
+BenchmarkFanLiaoLibrary/Set-16                                   7468802               146.2 ns/op
+BenchmarkFanLiaoLibrary/Mix-16                                  27911967                42.55 ns/op
+BenchmarkTidwallLibrary/Get-16                                  60208870                20.19 ns/op
+BenchmarkTidwallLibrary/Set-16                                  15534781                72.84 ns/op
+BenchmarkTidwallLibrary/Mix-16                                  38839478                31.34 ns/op
+BenchmarkDustinxieLibrary/Get-16                                37977000                32.64 ns/op
+BenchmarkDustinxieLibrary/Set-16                                 5389324               206.1 ns/op
+BenchmarkDustinxieLibrary/Mix-16                                 7166394               165.0 ns/op
+BenchmarkSyncMap/Get-16                                         61196125                19.48 ns/op
+BenchmarkSyncMap/Set-16                                          1000000              2306 ns/op
+BenchmarkSyncMap/Mix-16                                         41027619                25.55 ns/op
 ```


### PR DESCRIPTION
The idea here is that the benchmark not be constrained by the speed of generating random strings. Instead the strings will be generated before hand as to remove their timing from the final numbers.